### PR TITLE
add missing import for NexposeAPI on vuln_update()

### DIFF
--- a/controllers/nexpose.py
+++ b/controllers/nexpose.py
@@ -175,6 +175,7 @@ def vuln_update():
 
     from lxml import etree
     from StringIO import StringIO
+    import NexposeAPI as nexpose_api
 
     response.title = "%s :: Nexpose Vulnerability Update" % (settings.title)
     form = SQLFORM.factory(


### PR DESCRIPTION
when importing from nexpose, this function calls nexpose_api.NexposeAPI but nexpose_api doesnt exist do web2py trows a tantrum
