### PR TITLE
Fix tables for services / asset group on index + minor touchups

### DIFF
--- a/views/default/index.html
+++ b/views/default/index.html
@@ -212,27 +212,57 @@ $(function () {
     </div>
 
   <div class="widget-box">
-       <div class="widget-title">
-        <h5>Asset Groups</h5>
-       </div>
         <div class="widget-content">
-            {{
-              count=db.t_hosts.f_asset_group.count()
-              =SQLTABLE(db().select(db.t_hosts.f_asset_group, count, groupby=db.t_hosts.f_asset_group), headers={'t_hosts.f_asset_group':'Asset Group', 'COUNT(t_hosts.f_asset_group)':'Count'}, _style='width:100%')
-            }}
+            <table class="table table-bordered table-hover">
+               <thead>
+                 <tr>
+                     <th>Asset Group Name</th>
+                     <th>Host Count</th>
+                 </tr>
+               </thead>
+               <tbody>
+               {{
+                  host_count=db.t_hosts.f_asset_group.count()
+                  for row in db().select(db.t_hosts.f_asset_group, host_count, groupby=db.t_hosts.f_asset_group):
+               }}
+                 <tr>
+                     <td>{{=row['t_hosts.f_asset_group']}}</td>
+                     <td>{{=row[host_count]}}</td>
+                 </tr>
+              {{pass}}
+              </tbody>
+            </table>
         </div>
       </div>
     </div>
   </div>
+
   <div class="widget-box">
         <div class="widget-title">
           <h5>Top Services</h5>
         </div>
         <div class="widget-content">
-            {{
-              count=db.t_services.f_proto.count()
-              =SQLTABLE(db().select(db.t_services.f_proto, db.t_services.f_number, db.t_services.f_name, count, groupby=db.t_services.f_proto|db.t_services.f_number|db.t_services.f_name,orderby=~count,limitby=(0,15)), headers={'t_services.f_proto':'Protocol', 't_services.f_number':'Number', 't_services.f_name':'Name', 'COUNT(t_services.f_proto)':'Count'}, _style='width:99%')
-            }}
+            <table class="table table-bordered table-hover">
+               <thead>
+                 <tr>
+                     <th>Protocol</th>
+                     <th>Name</th>
+                     <th>Count</th>
+                 </tr>
+               </thead>
+               <tbody>
+                {{
+                  svc_count=db.t_services.f_proto.count()
+                  for row in db().select(db.t_services.f_proto, db.t_services.f_number, db.t_services.f_name, svc_count, groupby=db.t_services.f_proto|db.t_services.f_number|db.t_services.f_name,orderby=~svc_count,limitby=(0,15)):
+                }}
+                 <tr>
+                     <td>{{="%s/%s" % (row['t_services.f_proto'], row['t_services.f_number'])}}</td>
+                     <td>{{=row['t_services.f_name']}}</td>
+                     <td>{{=row[svc_count]}}</td>
+                 </tr>
+                {{pass}}
+              </tbody>
+            </table>
         </div>
     </div>
 </div>

--- a/views/hosts/detail.html
+++ b/views/hosts/detail.html
@@ -109,41 +109,43 @@
             <li><a href="#netbios_info" data-toggle="tab">Net<u>B</u>IOS</a></li>
         </ul>
 
-    <div id="TabContent" class="tab-content">
-        <div class="tab-pane active" id="aa_list" >
-            {{=LOAD('vulns','aa_by_host.load',args=[host.record.id],ajax=False,target='aa_list')}}
-        </div>
-
-        <div class="tab-pane" id="service_list">
-            {{=LOAD('services','by_host.load',args=[host.record.id],ajax=False,target='service_list')}}
-        </div>
-
-        <div class="tab-pane" id="vulns_list">
-            {{=LOAD('vulns','vulndata_by_host.load',args=[host.record.id],ajax=False,target='vulns_list')}}
-        </div>
-
-        <div class="tab-pane" id="evidence_list">
-            {{=LOAD('evidence', 'list.load', args=[host.record.id], ajax=False,target='evidence_list')}}
-        </div>
-
-        <div class="tab-pane" id="os_list">
-            {{=LOAD('os','refs_by_host.load',args=[host.record.id],ajax=False,target='os_list')}}
-        </div>
-
-        <div class="tab-pane" id="accounts_list">
-            {{=LOAD('accounts', 'by_host.load', args=[host.record.id], ajax=False,target='accounts_list')}}
-        </div>
-
-        <div class="tab-pane" id="snmp_list">
-            {{=LOAD('snmp', 'by_host.load', args=[host.record.id], ajax=False,target='snmp_list')}}
-        </div>
-
-        <div class="tab-pane" id="netbios_info">
-            <div class="span8" id="netbios_form">
-                {{=LOAD('netbios', 'by_host.load', args=[host.record.id], ajax=True, target='netbios_form')}}
+        <div id="TabContent" class="tab-content">
+            <div class="tab-pane active" id="aa_list" >
+                {{=LOAD('vulns','aa_by_host.load',args=[host.record.id],ajax=False,target='aa_list')}}
             </div>
+
+            <div class="tab-pane" id="service_list">
+                {{=LOAD('services','by_host.load',args=[host.record.id],ajax=False,target='service_list')}}
+            </div>
+
+            <div class="tab-pane" id="vulns_list">
+                {{=LOAD('vulns','vulndata_by_host.load',args=[host.record.id],ajax=False,target='vulns_list')}}
+            </div>
+
+            <div class="tab-pane" id="evidence_list">
+                {{=LOAD('evidence', 'list.load', args=[host.record.id], ajax=False,target='evidence_list')}}
+            </div>
+
+            <div class="tab-pane" id="os_list">
+                {{=LOAD('os','refs_by_host.load',args=[host.record.id],ajax=False,target='os_list')}}
+            </div>
+
+            <div class="tab-pane" id="accounts_list">
+                {{=LOAD('accounts', 'by_host.load', args=[host.record.id], ajax=False,target='accounts_list')}}
+            </div>
+
+            <div class="tab-pane" id="snmp_list">
+                {{=LOAD('snmp', 'by_host.load', args=[host.record.id], ajax=False,target='snmp_list')}}
+            </div>
+
+            <div class="tab-pane" id="netbios_info">
+                <div class="span8" id="netbios_form">
+                    {{=LOAD('netbios', 'by_host.load', args=[host.record.id], ajax=True, target='netbios_form')}}
+                </div>
+            </div>
+
         </div>
-    </div>
+
     </div>
 
 </div>

--- a/views/metasploit/bruteforce.html
+++ b/views/metasploit/bruteforce.html
@@ -231,12 +231,12 @@ $(document).ready(function(){
 
     $("#btn-services-all").on("click", function(){
         $("#msfpro_bruteforce_services option").prop("selected", true);
-        $("#msfpro_bruteforce_services").trigger("chosen:updated");
+        //$("#msfpro_bruteforce_services").trigger("chosen:updated");
     });
 
     $("#btn-services-none").on("click", function(){
         $("#msfpro_bruteforce_services option").prop("selected", false);
-        $("#msfpro_bruteforce_services").trigger("chosen:updated");
+        //$("#msfpro_bruteforce_services").trigger("chosen:updated");
     });
 });
 </script>

--- a/views/metasploit/exploit.html
+++ b/views/metasploit/exploit.html
@@ -188,12 +188,12 @@ $(document).ready(function(){
 
     $("#btn-modules-all").on("click", function(){
         $("#msfpro_exploit_modules option").prop("selected", true);
-        $("#msfpro_exploit_modules").trigger("chosen:updated");
+        //$("#msfpro_exploit_modules").trigger("chosen:updated");
     });
 
     $("#btn-modules-none").on("click", function(){
         $("#msfpro_exploit_modules option").prop("selected", false);
-        $("#msfpro_exploit_modules").trigger("chosen:updated");
+        //$("#msfpro_exploit_modules").trigger("chosen:updated");
     });
 });
 </script>


### PR DESCRIPTION
Count fields no longer work in web2py's SQLTABLE due to big changes in sqlhtml.py. Whether or not this was intentional or if I was using this incorrectly the service and asset group count tables on the default/index.html page are manually generated.

Also did some formatting changes and select2 fixes.
