### PR TITLE
nmap-import: Use safe method to access dict

### DIFF
--- a/modules/skaldship/nmap.py
+++ b/modules/skaldship/nmap.py
@@ -180,7 +180,8 @@ def process_xml(
             host_id = None
             f_title = os['name'] #title
             for k in os['osclasses']:
-                f_cpename= k['cpe'].lstrip('cpe:/o:')
+                if k.get('cpe') != None:
+                    f_cpename= k['cpe'].lstrip('cpe:/o:')
                 f_vendor = k['vendor']
                 f_product = k['osfamily']
                 f_version = k['osgen']


### PR DESCRIPTION
Stepped on this bug while importing nmap xml file ended up in
a python keyerror.

Solved by first check if cpe exists through dict.get() as safe method.

See also:

``` python
Traceback (most recent call last):
  File "/opt/web2py/gluon/restricted.py", line 220, in restricted
    exec ccode in environment
  File "/opt/web2py/applications/kvasir/controllers/nmap.py", line 245, in <module>
  File "/opt/web2py/gluon/globals.py", line 389, in <lambda>
    self._caller = lambda f: f()
  File "/opt/web2py/gluon/tools.py", line 3283, in f
    return action(*a, **b)
  File "/opt/web2py/applications/kvasir/controllers/nmap.py", line 145, in import_xml_scan
    update_hosts=form.vars.f_update_hosts,
  File "applications/kvasir/modules/skaldship/nmap.py", line 183, in process_xml
    f_cpename= k['cpe'].lstrip('cpe:/o:')
KeyError: 'cpe'
```
