### PR TITLE
Fix CPE Import Backgroundtask - UnboundLocalError

### DIFF
--- a/controllers/exploits.py
+++ b/controllers/exploits.py
@@ -125,6 +125,7 @@ def connect_exploits():
         Field('f_taskit', type='boolean', default=auth.user.f_scheduler_tasks, label=T('Run in background task')),
     )
 
+    from skaldship.exploits import connect_exploits
     if form.accepts(request.vars, session):
         if form.vars.f_taskit:
             task = scheduler.queue_task(
@@ -138,7 +139,6 @@ def connect_exploits():
             else:
                 response.flash = "Error submitting job: %s" % (task.errors)
         else:
-            from skaldship.exploits import connect_exploits
             connect_exploits()
             response.flash = "Exploits and vulnerabilities connected"
             redirect(URL('list'))


### PR DESCRIPTION
It should be imported before use :)

This fixes following:
<type 'exceptions.UnboundLocalError'> local variable 'connect_exploits' referenced before assignment

Traceback (most recent call last):
  File "/opt/kvasir/web2py/gluon/restricted.py", line 220, in restricted
    exec ccode in environment
  File "/opt/kvasir/web2py/applications/test/controllers/exploits.py", line 264, in <module>
  File "/opt/kvasir/web2py/gluon/globals.py", line 389, in <lambda>
    self._caller = lambda f: f()
  File "/opt/kvasir/web2py/gluon/tools.py", line 3337, in f
    return action(_a, *_b)
  File "/opt/kvasir/web2py/applications/test/controllers/exploits.py", line 131, in connect_exploits
    connect_exploits,
UnboundLocalError: local variable 'connect_exploits' referenced before assignment
