### PR TITLE
replace not lstrip (fixes #86), add doctests, os del fix

### DIFF
--- a/controllers/os.py
+++ b/controllers/os.py
@@ -87,6 +87,21 @@ def list():
 
         return dict(add=add)
 
+@auth.requires_signature()
+@auth.requires_login()
+def delete():
+    count = 0
+    for r in request.vars.ids.split('|'):
+        if r is not None:
+            db(db.t_os.id == r).delete()
+            count += 1
+    db.commit()
+    response.flash = "%s OS record(s) deleted" % (count)
+    response.headers['web2py-component-command'] = "ostable.fnReloadAjax(); jQuery('.datatable tr.DTTT_selected').removeClass('DTTT_selected');"
+    #response.js = "hosttable.fnReloadAjax(); jQuery('.datatable tr.DTTT_selected').removeClass('DTTT_selected');"
+
+    return dict()
+
 ##-------------------------------------------------------------------------
 ## references
 ##-------------------------------------------------------------------------
@@ -297,7 +312,7 @@ def mass_assign():
                 os_id = None
                 if cpe:
                     # we have a cpe entry from xml! hooray!
-                    cpe_name = cpe.lstrip('cpe:/o:')
+                    cpe_name = cpe.replace('cpe:/o:', '')
                     os_id = lookup_cpe(cpe_name)
                 #else:
                     # no cpe attribute in xml, go through our messsy lookup

--- a/modules/skaldship/nessus.py
+++ b/modules/skaldship/nessus.py
@@ -669,8 +669,8 @@ def process_scanfile(
             ### Operating Systems and CPE
             if pluginID == '45590':
                 # Common Platform Enumeration (CPE)
-                for cpe_os in re.findall('(cpe:/o:.*)', plugin_output):
-                    os_id = lookup_cpe(cpe_os.lstrip('cpe:/o:'))
+                for cpe_os in re.findall('(cpe:/o:.*? )', plugin_output):
+                    os_id = lookup_cpe(cpe_os.replace('cpe:/o:', '').rstrip(' '))
                     if os_id:
                         db.t_host_os_refs.update_or_insert(
                             f_certainty='0.90',     # just a stab

--- a/modules/skaldship/nexpose.py
+++ b/modules/skaldship/nexpose.py
@@ -966,7 +966,7 @@ def process_xml(
 
             if os_rec.attrib.has_key('cpe'):
                 # we have a cpe entry from xml! hooray!
-                cpe_name = os_rec.attrib['cpe'].lstrip('cpe:/o:')
+                cpe_name = os_rec.attrib['cpe'].replace('cpe:/o:', '')
                 os_id = lookup_cpe(cpe_name)
             else:
                 # no cpe attribute in xml, go through our messy lookup

--- a/modules/skaldship/nmap.py
+++ b/modules/skaldship/nmap.py
@@ -181,7 +181,7 @@ def process_xml(
             f_title = os['name'] #title
             for k in os['osclasses']:
                 if k.get('cpe') != None:
-                    f_cpename= k['cpe'].lstrip('cpe:/o:')
+                    f_cpename= k['cpe'].replace('cpe:/o:', '')
                 f_vendor = k['vendor']
                 f_product = k['osfamily']
                 f_version = k['osgen']
@@ -300,7 +300,7 @@ def process_xml(
             # Process <cpe> service entries
             port_cpe = port.get('service_cpe')
             if port_cpe:
-                cpe_id = port_cpe.lstrip('cpe:/')
+                cpe_id = port_cpe.replace('cpe:/', '')
 
                 if cpe_id.startswith('a'):
                     # process CPE Applications

--- a/modules/skaldship/qualys.py
+++ b/modules/skaldship/qualys.py
@@ -233,7 +233,7 @@ def process_xml(
 
             # Process <cpe> service entries
             for port_cpe in port.findall('service/cpe'):
-                cpe_id = port_cpe.text.lstrip('cpe:/')
+                cpe_id = port_cpe.text.replace('cpe:/', '')
 
                 if cpe_id[0] == "a":
                     # process CPE Applications

--- a/views/os/list.html
+++ b/views/os/list.html
@@ -56,13 +56,13 @@ jQuery(document).ready(function() {
         },
     } );
 
-    $("#del_os").click(function(e) {
+    $("#delete_os").click(function(e) {
         e.preventDefault();
 
         //bootbox.options.onEscape =
         bootbox.confirm('These items will be permanently deleted and cannot be recovered. Are you sure?', "Cancel", "Delete", function(confirmed) {
             if(confirmed) {
-                var checks = dt_checkboxer_select_DT_RowIds(hosttable);
+                var checks = dt_checkboxer_select_DT_RowIds(ostable);
                 if (checks == '') { alert('Nothing selected'); return false; }
                 var data = "ids=" + checks;
                 url = "{{=URL('os', 'delete.json', user_signature=True)}}";


### PR DESCRIPTION
lstrip is cool but evil. Use replace to remove cpe:/o:. fixes #86

Added doctests to cpe.py module in small attempt to actually tdd.

Restore the ability to delete from t_os
