### PR TITLE
Customization comes to Kvasir!

### DIFF
--- a/kvasir.yaml.sample
+++ b/kvasir.yaml.sample
@@ -78,6 +78,18 @@ security_key: "sha512:36518081-c858-47ad-8832-a28d842f3052"
 
 ##########################################################################################################
 #
+# Customization
+#
+##########################################################################################################
+
+# Login page image. File must be under static/ subdirectory.
+login_image: images/Kvasir_portrait.png
+
+# Loading video - can be a movie file (mp4/m4v) or comment it out for a progress bar.
+loading_video: videos/loading.m4v
+
+##########################################################################################################
+#
 # Web2py scheduler settings
 #
 # scheduler_group_name:

--- a/models/00_settings.py
+++ b/models/00_settings.py
@@ -106,3 +106,9 @@ settings.exploitdb_path = settings.kvasir_config.get('exploitdb_path', None)
 
 # redirect_timer
 settings.redirect_timer = settings.kvasir_config.get('redirect_timer', 10)
+
+# Login image. File must be under static/ subdirectory
+settings.login_image = settings.kvasir_config.get('login_image', 'images/Kvasir_portrait.png')
+
+# Loading video - can be a movie file (mp4/m4v) or None
+settings.loading_video = settings.kvasir_config.get('loading_video', None)

--- a/views/default/user.html
+++ b/views/default/user.html
@@ -3,7 +3,7 @@
 {{if request.args(0)=='login':}}
     <div class="span4">
         <div id="signin-logo">
-            <img src="{{=URL('static', '/images/Kvasir_portrait.png')}}">
+            <img src="{{=URL('static', settings.login_image)}}">
         </div>
     </div>
 {{pass}}

--- a/views/loading.html
+++ b/views/loading.html
@@ -4,10 +4,16 @@
     <h3>Please wait...</h3>
   </div>
   <div class="modal-body">
+    {{if settings.loading_video:}}
     <video id="loadingvid" controls="controls" loop="loop" style="max-width:inherit;">
-        <source src="{{=URL('static', 'videos/loading.m4v')}}" type="video/mp4"/>
+        <source src="{{=URL('static', settings.loading_video)}}" type="video/mp4"/>
         Your browser does not support the video tag.
     </video>
+    {{else:}}
+    <div class="progress progress-striped active">
+        <div class="bar" style="width: 100%;"></div>
+    </div>
+    {{pass}}
   </div>
 </div>
 
@@ -19,6 +25,7 @@ $(document).ready(function() {
 
     //document.getElementById('loadingvid').pause();
 
+    {{if settings.loading_video:}}
     jQuery('#loading_modal').on('show', function() {
         document.getElementById('loadingvid').play();
     });
@@ -26,6 +33,7 @@ $(document).ready(function() {
     jQuery('#loading_modal').on('hide', function() {
         document.getElementById('loadingvid').pause();
     });
+    {{pass}}
 
     jQuery('input[type="submit"]').click( function() {
       jQuery('form').submit();


### PR DESCRIPTION
Customization of the login page and use of the dddddddada daa da da AFRO CIRCUS loading video have come to Kvasir. (fixes #92)

If you want to use a different image for the login page, set it in your kvasir.yaml file. Your image must exist under the static/ directory.

Some people love Afro Circus. Others have become tired of it. Now you can point the loading video to something else! This must also reside under the static/ directory. Comment out loading_video in your kvasir.yaml file for a dull and boring progress animation bar. Actual progress not shown.
