### PR TITLE
Fixes - global name XXX is not defined

### DIFF
--- a/modules/skaldship/passwords/utils.py
+++ b/modules/skaldship/passwords/utils.py
@@ -19,7 +19,9 @@ import string
 from gluon import current
 import logging
 from ..log import log
-
+from .medusa import process_medusa
+from .hydra import process_hydra
+from .metasploit import process_msfcsv
 
 # Module definitions
 lowercase = set(string.lowercase)


### PR DESCRIPTION
Fixes following errors:

ERROR:web2py.app.kvasir:Error with line (ACCOUNT FOUND: [snmp] Host: 1.3.0.2 User: (null) Password: blah [SUCCESS]): global name 'process_medusa' is not defined
ERROR:web2py.app.kvasir:Error with line (blah,,,,): global name 'process_msfcsv' is not defined
