### PR TITLE
Kvasir-173 pyDal changes Row()

### DIFF
--- a/modules/skaldship/valkyries/vncscreenshot.py
+++ b/modules/skaldship/valkyries/vncscreenshot.py
@@ -90,7 +90,10 @@ def do_screenshot(services=None):
     Grab a screenshot and import it to the evidence db.
     """
 
-    from gluon.dal import Row
+    try:
+        from pydal.objects import Row
+    except ImportError:
+        from gluon.dal import Row
     from gluon import current
     import os
     from skaldship.general import check_datadir

--- a/modules/skaldship/valkyries/webimaging.py
+++ b/modules/skaldship/valkyries/webimaging.py
@@ -85,7 +85,10 @@ def do_screenshot(services=None):
     Grab a screenshot of a URL and import it to the evidence db.
     """
 
-    from gluon.dal import Row
+    try:
+        from pydal.objects import Row
+    except ImportError:
+        from gluon.dal import Row
     from skaldship.general import check_datadir
 
     db = current.globalenv['db']


### PR DESCRIPTION
Row() is no longer in gluon.dal as of web2py 2.9.12. This puts a
try-exception bock around to support both old and new modules.