### PR TITLE
Nessus6 API Support

### DIFF
--- a/kvasir.yaml.sample
+++ b/kvasir.yaml.sample
@@ -1,6 +1,6 @@
 ##########################################################################################################
 #
-# Kvasir Configuration file.
+# Kvasir Configuration file for Docker deployment
 #
 # Lookup priority:
 #
@@ -21,8 +21,8 @@ db:
   lazy_tables: false      # set this to True after setup is complete for faster db access
   kvasir:
     # any web2py supported URI connection string is acceptable - additional libraries may be required
-    # see ttp://web2py.com/books/default/chapter/29/06#Connection-strings
-    uri: postgres://pguser:pgpass@localhost:5432/kvasir
+    # see http://web2py.com/books/default/chapter/29/06#Connection-strings
+    uri: postgres://kvuser:kvpass@localhost:5432/kvasir
     pool_size: 10
   msf:
     # direct msf db support is not currently supported - future support planned
@@ -155,8 +155,12 @@ nessus:
   servers: [
     server_name: {
       url: 'https://localhost:8834/',
-      user: admin,
-      password: password,
+      secret_key: ''',
+      access_key: '',
+      username: '',
+      password: '',
+      version: 6,
+      verify_ssl: false
     },
   ]
   ignored_plugins: [

--- a/modules/skaldship/nessus/__init__.py
+++ b/modules/skaldship/nessus/__init__.py
@@ -34,8 +34,13 @@ def nessus_get_config():
         for k,v in server.iteritems():
             config['servers'][k] = {
                 'url': v.get('url', 'http://localhost:8834/'),
-                'user': v.get('user', 'admin'),
-                'password': v.get('password', 'password')
+                'user': v.get('user'),
+                'password': v.get('password'),
+                'access_key': v.get('access_key'),
+                'secret_key': v.get('secret_key'),
+                'verify_ssl': v.get('verify_ssl'),
+                'proxies': v.get('proxies'),
+                'version': v.get('version', 6)
             }
 
     return config

--- a/modules/skaldship/nessus/ness6api.py
+++ b/modules/skaldship/nessus/ness6api.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python
+"""
+Nessus 6 API
+
+Only does the things we need to do:
+
+ - Authenticate
+ - List scans
+ - Download scan data
+"""
+
+import requests
+import time
+import logging
+
+logging.basicConfig(level=logging.DEBUG)
+logger = logging.getLogger('nessus6api')
+
+
+class Nessus6API:
+    def __init__(self, url=None, username=None, password=None, access_key=None, secret_key=None, verify=True, proxies=None):
+        self.session = requests.Session()
+        self.url = url
+        if self.url.endswith('/'):
+            self.url = self.url[:-1]
+        self.username = username
+        self.password = password
+        self.access_key = access_key
+        self.secret_key = secret_key
+        self.verify = verify
+        self.proxies = proxies
+        self.is_authenticated = False
+        self.token = None
+        self.folders = []
+        self.login()
+
+    def _send(self, url, data={}, json={}, method='POST'):
+        if self.is_authenticated is False:
+            self.login()
+        if method == 'GET':
+            if self.proxies:
+                req = self.session.get(url=url, data=data, json=json, verify=self.verify, proxies=self.proxies)
+            else:
+                req = self.session.get(url=url, data=data, json=json, verify=self.verify)
+        elif method == 'POST':
+            if self.proxies:
+                req = self.session.post(url=url, data=data, json=json, verify=self.verify, proxies=self.proxies)
+            else:
+                req = self.session.post(url=url, data=data, json=json, verify=self.verify)
+
+        return req
+
+    def login(self):
+        self.is_authenticated = False
+        self.token = None
+        if 'X-Cookie' in self.session.headers:
+            self.session.headers.pop('X-Cookie')
+        url = "{0}/session".format(self.url)
+        if self.username and self.password:
+            data = {
+                'username': self.username,
+                'password': self.password
+            }
+            res = self.session.post(url, json=data, proxies=self.proxies, verify=self.verify)
+            contents = res.json()
+            self.token = contents['token']
+            self.is_authenticated = True
+            self.session.headers.update({'X-Cookie': 'token={0}'.format(self.token)})
+        elif self.access_key and self.secret_key:
+            self.is_authenticated = True
+            self.session.headers.update(
+                {'X-ApiKeys': 'accessKey={0}; secretKey={1};'.format(self.access_key, self.secret_key)}
+            )
+        else:
+            raise Exception('No username or API keys provided')
+
+    def get_folders(self):
+        url = '{0}/folders'.format(self.url)
+        res = self._send(url, method='GET')
+        if res.status_code == 200:
+            self.folders = res.json()['folders']
+        elif res.status_code == 403:
+            raise Exception(res.reason)
+        else:
+            return res
+        return self.folders
+
+    def get_scans(self, folder_id=None):
+        if folder_id is None:
+            url = '{0}/scans'.format(self.url)
+        else:
+            url = '{0}/scans?folder_id={1}'.format(self.url, folder_id)
+        res = self._send(url, method='GET')
+        if res.status_code == 200:
+            return res.json()['scans']
+        else:
+            raise Exception(res.reason)
+
+    def scan_export(self, scan_id):
+        """This is a bit of a hack, only downloads nessus format where API can do more"""
+        url = '{0}/scans/{1}/export'.format(self.url, str(scan_id))
+        data = {
+            'chapters': None,
+            'format': 'nessus'
+        }
+        res = self._send(url, json=data, method='POST')
+        if res.status_code == 200:
+            return res.json()['file']
+        elif res.status_code == 400:
+            raise Exception('Missing parameters')
+        elif res.status_code == 404:
+            raise Exception('Scan does not exist')
+        else:
+            raise Exception(res.reason)
+
+    def export_status(self, scan_id, file_id):
+        url = '{0}/scans/{1}/export/{2}/status'.format(self.url, scan_id, file_id)
+        res = self._send(url, method='GET')
+        if res.status_code == 200:
+            return res.json()['status']
+        elif res.status_code == 404:
+            raise Exception('Scan or file does not exist')
+        else:
+            raise Exception(res.reason)
+
+    def scan_download(self, scan_id, file_id):
+        url = '{0}/scans/{1}/export/{2}/download'.format(self.url, scan_id, file_id)
+        res = self._send(url, method='GET')
+        if res.status_code == 200:
+            return res.content
+        elif res.status_code == 404:
+            raise Exception('Scan or file does not exist')
+        else:
+            raise Exception(res.reason)
+
+    def report_download(self, scan_id, time_delay=5):
+        """Bundles scan_export and scan_download together"""
+        file_id = self.scan_export(scan_id)
+        status = ''
+        count = 0
+        while status != 'ready':
+            if count > 5:
+                raise Exception('Report download timed out')
+            status = self.export_status(scan_id, file_id)
+            logger.debug('status = {0}'.format(status))
+            count += 1
+            if status != 'ready':
+                time.sleep(time_delay)
+
+        contents = self.scan_download(scan_id, file_id)
+        return contents
+
+
+if __name__ == '__main__':
+    from pprint import pprint
+    #n = Nessus6API(url='https://localhost:8834', 'username', 'password', verify=False)
+    n = Nessus6API(
+        url='https://localhost:8834', secret_key='f23a0072b5ce3a701c4105553cf029fa1a8ff0a2f3de91207c006f3bfa71d5a4',
+        access_key='492371350d7aadf5220223c6f64733338aa741fc52aada2fcd09b7b8dcaf387d', verify=False
+    )
+
+    folders = n.get_folders()
+    pprint(folders)
+
+    print("\n\n")
+    scans = n.get_scans()
+    pprint(scans)
+


### PR DESCRIPTION
This adds support for the Nessus 6 REST API and is based on various
code found on Github. Thanks to everyone who has worked on this in
the past, especially @jfalken

kvasir.yaml settings to use Nessus 6 include:

```
nessus:
  servers: [
    server_name: {
      url: 'https://localhost:8834/',
      secret_key: ''',
      access_key: '',
      username: '',
      password: '',
      version: 6,
      verify_ssl: false
    },
  ]
```

where:

 * secret_key / access_key: your API keys, remove if not used
 * username / password: your username and password, remove if not used
 * verify_ssl: true if you have a trusted certificate, otherwise false

If you use API key, do not set username/password and vice-versa.